### PR TITLE
Compiler warning fixes

### DIFF
--- a/src/main/java/se/ranzdo/bukkit/methodcommand/Command.java
+++ b/src/main/java/se/ranzdo/bukkit/methodcommand/Command.java
@@ -5,6 +5,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.bukkit.command.CommandSender;
+
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface Command {

--- a/src/main/java/se/ranzdo/bukkit/methodcommand/Flags.java
+++ b/src/main/java/se/ranzdo/bukkit/methodcommand/Flags.java
@@ -10,7 +10,7 @@ import java.lang.annotation.Target;
 public @interface Flags {
 	String[] description() default {};
 	/**
-	 * @return
+	 * @return description of flag
 	 */
 	String[] identifier();
 }


### PR DESCRIPTION
Fixed annoying compiler warnings.

Fixed Eclipse Whining..
Eclipse whines about missing return statement on javadocs. 
{@link CommandSender} also threw eclipse warnings. Simple import.
